### PR TITLE
refactor: RESTful한 URI 구조로 API 엔드포인트 개선 (member, chat)

### DIFF
--- a/src/main/java/com/example/chatserver/chat/controller/ChatController.java
+++ b/src/main/java/com/example/chatserver/chat/controller/ChatController.java
@@ -20,50 +20,50 @@ public class ChatController {
 
     private final ChatService chatService;
 
-    @PostMapping("/room/group/create")
+    @PostMapping("/group")
     public ResponseEntity<?> createGroupRoom(@RequestParam("roomName") String roomName) {
         chatService.createGroupRoom(roomName);
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/room/group/list")
+    @GetMapping("/groups")
     public ResponseEntity<?> getGroupChatRooms() {
         List<ChatRoomListResDto> list = chatService.getGroupChatRooms();
         return new ResponseEntity<>(list, HttpStatus.OK);
 
     }
 
-    @PostMapping("/room/group/join/{roomId}")
+    @PostMapping("/group/{roomId}/join")
     public ResponseEntity<?> joinGroupChatRoom(@PathVariable("roomId") Long roomId) {
         chatService.joinGroupChat(roomId);
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/room/group/history/{roomId}")
+    @GetMapping("/group/{roomId}/history")
     public ResponseEntity<?> getChatHistory(@PathVariable("roomId") Long roomId) {
         List<ChatMessageDto> histories = chatService.getChatHistory(roomId);
         return new ResponseEntity<>(histories, HttpStatus.OK);
     }
 
-    @PostMapping("/room/read/{roomId}")
+    @PostMapping("/{roomId}/read")
     public ResponseEntity<?> readChatRoom(@PathVariable("roomId") Long roomId) {
         chatService.messageRead(roomId);
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/room/mychat")
+    @GetMapping("/personal-rooms")
     public ResponseEntity<?> getMyChat() {
         List<MyChatListResDto> dtos = chatService.getMyChatRooms();
         return new ResponseEntity<>(dtos, HttpStatus.OK);
     }
 
-    @DeleteMapping("/room/group/leave/{roomId}")
+    @DeleteMapping("/group/{roomId}")
     public ResponseEntity<?> leaveGroupChatRoom(@PathVariable("roomId") Long roomId) {
         chatService.leaveGroupChatRoom(roomId);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/room/private/create")
+    @PostMapping("/private")
     public ResponseEntity<?> getOrCreatePrivateChatRoom(@RequestParam("otherMemberId") Long otherMemberId) {
         Long roomId = chatService.getOrCreatePrivateRoom(otherMemberId);
         PrivateChatRoomResDto dto = PrivateChatRoomResDto.builder()

--- a/src/main/java/com/example/chatserver/member/controller/MemberController.java
+++ b/src/main/java/com/example/chatserver/member/controller/MemberController.java
@@ -26,13 +26,13 @@ public class MemberController {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    @PostMapping("/create")
+    @PostMapping
     public ResponseEntity<?> memberCreate(@RequestBody MemberSaveReqDto memberSaveReqDto) {
         Member member = memberService.create(memberSaveReqDto);
         return new ResponseEntity<>(member.getId(), HttpStatus.CREATED);
     }
 
-    @PostMapping("/doLogin")
+    @PostMapping("/login")
     public ResponseEntity<?> doLogin(@RequestBody MemberLoginReqDto memberLoginReqDto) {
         Member member = memberService.login(memberLoginReqDto);
         // access-token 발행


### PR DESCRIPTION
## 관련 이슈 
Issue #1 

## 영향도
- 프론트엔드 memberApi, chatApi 전체 경로 수정 필요

## 작업 내용

기존 API URI가 RESTful하지 않은 구조(동사 위주)로 설계되어 있어 다음과 같은 개선 작업을 수행

- ✅ 리소스 중심의 URI 설계로 전환
- ✅ HTTP 메서드의 의미와 URI의 리소스를 일치시킴
- ✅ 향후 확장성을 고려한 계층 구조 정비

## 작업 결과
### 🔹 MemberController

| AS-IS                     | TO-BE              |
|--------------------------|--------------------|
| POST /member/doLogin     | POST /member/login |
| POST /member/create      | POST /member       |
| GET /member/list         | GET /member/list   |

### 🔹 ChatController

| AS-IS                                      | TO-BE                           |
|-------------------------------------------|---------------------------------|
| POST /chat/room/read/{roomId}             | POST /chat/{roomId}/read        |
| POST /chat/room/private/create            | POST /chat/private              |
| POST /chat/room/group/join/{roomId}       | POST /chat/group/{roomId}/join  |
| POST /chat/room/group/create              | POST /chat/group                |
| GET /chat/room/mychat                     | GET /chat/personal-rooms        |
| GET /chat/room/group/list                 | GET /chat/groups                |
| GET /chat/room/group/history/{roomId}     | GET /chat/{roomId}/history      |
| DELETE /chat/room/group/leave/{roomId}    | DELETE /chat/group/{roomId}     |

## 기타
- SpringDocs 기반 Swagger 문서 URI도 함께 변경됨 (자동 반영됨)
- 기존 경로 사용하는 경우 오류 발생 가능하므로, FE 리팩토링 병행 필요
